### PR TITLE
Feature: pass on existing mqtt connection, bump mqtt version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "typescript": "^4.1.5"
   },
   "dependencies": {
-    "mqtt": "^4.2.6"
+    "mqtt": "^5.3.0"
   }
 }

--- a/src/dynsec.ts
+++ b/src/dynsec.ts
@@ -1,6 +1,6 @@
 
-import {connect, MqttClient} from "mqtt"
-import {AddRoleACLRequest, CreateClientRequest, GetClientResponse, ListClientsResponse, ListGroupsResponse, ListRequest, ListRolesResponse, RemoveRoleACLRequest} from "./command_types"
+import {connect, MqttClient} from "mqtt";
+import {AddRoleACLRequest, CreateClientRequest, GetClientResponse, ListClientsResponse, ListGroupsResponse, ListRequest, ListRolesResponse, RemoveRoleACLRequest} from "./command_types";
 
 
 export interface ConnectOptions {
@@ -69,6 +69,10 @@ export class MosquittoDynsec {
       }
 
     })
+  }
+
+  setConnection(mqtt: MqttClient) {
+    this.mqtt = mqtt
   }
 
   connect(options: ConnectOptions = {}): Promise<void> {


### PR DESCRIPTION
This little extension enables us to pass on an existing MQTT connection; that way we're able to set additional security features and re-use the connection in the module.
Besides, we bumped the mqtt dependency to a recent version (5.3.0+)